### PR TITLE
Fixed native function invocation style setting

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -50,6 +50,9 @@ return function (ECSConfig $ecsConfig): void {
     $ecsConfig->ruleWithConfiguration(FunctionDeclarationFixer::class, [
         'closure_fn_spacing' => 'none',
     ]);
-    $ecsConfig->rule(NativeFunctionInvocationFixer::class);
+    $ecsConfig->ruleWithConfiguration(NativeFunctionInvocationFixer::class, [
+        'scope' => 'namespaced',
+        'include' => ['@all'],
+    ]);
     $ecsConfig->rule(FinalClassFixer::class);
 };

--- a/src/DependencyInjection/YokaiSafeCommandExtension.php
+++ b/src/DependencyInjection/YokaiSafeCommandExtension.php
@@ -22,7 +22,7 @@ final class YokaiSafeCommandExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../../config'));
         $loader->load('services.xml');
 
-        $commands = array_unique([
+        $commands = \array_unique([
             ...$config['standard'],
             ...$config['custom'],
         ]);

--- a/tests/CommandDisabledTest.php
+++ b/tests/CommandDisabledTest.php
@@ -27,7 +27,7 @@ final class CommandDisabledTest extends CommandTestCase
             self::assertDoesNotMatchRegularExpression(
                 '/' . $command . '/',
                 $out,
-                sprintf('Disabled command "%s" should not appear in commands listing.', $command)
+                \sprintf('Disabled command "%s" should not appear in commands listing.', $command)
             );
         }
     }
@@ -45,13 +45,13 @@ final class CommandDisabledTest extends CommandTestCase
         self::assertSame(
             ConsoleCommandEvent::RETURN_CODE_DISABLED,
             $exit,
-            sprintf('Running disabled command "%s" should return disabled return code.', $command)
+            \sprintf('Running disabled command "%s" should return disabled return code.', $command)
         );
 
         self::assertMatchesRegularExpression(
             '/This command has been disabled. Aborting.../',
             $output->fetch(),
-            sprintf('Disabled command "%s" should output message to tell it wont run.', $command)
+            \sprintf('Disabled command "%s" should output message to tell it wont run.', $command)
         );
     }
 

--- a/tests/Stubs/YokaiSafeCommandTestKernel.php
+++ b/tests/Stubs/YokaiSafeCommandTestKernel.php
@@ -37,11 +37,11 @@ final class YokaiSafeCommandTestKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir() . '/' . Kernel::VERSION . '/cache/' . $this->environment;
+        return \sys_get_temp_dir() . '/' . Kernel::VERSION . '/cache/' . $this->environment;
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir() . '/' . Kernel::VERSION . '/logs';
+        return \sys_get_temp_dir() . '/' . Kernel::VERSION . '/logs';
     }
 }


### PR DESCRIPTION
Wrong configuration with `NativeFunctionInvocationFixer` lead to doing the opposite of intended