### PR TITLE
bump tests to Symfony 7.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,11 @@ jobs:
           - php-version: '8.4'
             symfony-version: '6.4.*'
           - php-version: '8.2'
-            symfony-version: '7.1.*'
+            symfony-version: '7.2.*'
           - php-version: '8.3'
-            symfony-version: '7.1.*'
+            symfony-version: '7.2.*'
           - php-version: '8.4'
-            symfony-version: '7.1.*'
+            symfony-version: '7.2.*'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -45,7 +45,7 @@ jobs:
         uses: ./.github/actions/install
         with:
           php-version: '8.3'
-          symfony-version: '7.1.*'
+          symfony-version: '7.2.*'
       - name: "Run checkstyle with symplify/easy-coding-standard"
         run: vendor/bin/ecs
 
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions/install
         with:
           php-version: '8.4'
-          symfony-version: '7.1.*'
+          symfony-version: '7.2.*'
           coverage-mode: 'xdebug'
       - name: "Run tests with phpunit/phpunit"
         env:


### PR DESCRIPTION
I bumped the tests to just Symfony 7.2.  Should it also test 7.1?

I tried to update PHPUnit to 11.4, but ran into an issue with the [exception handler](https://github.com/sebastianbergmann/phpunit/issues/5721), and wasn't sure the best way to handle it.